### PR TITLE
Fixes constructor mismatch in JwtAuthenticationClient

### DIFF
--- a/ForceDotNetJwtCompanion/JwtAuthenticationClient.cs
+++ b/ForceDotNetJwtCompanion/JwtAuthenticationClient.cs
@@ -88,7 +88,7 @@ namespace ForceDotNetJwtCompanion
         public JwtAuthenticationClient(
             string apiVersion = "v50.0", 
             bool isProd = true
-            ) : this(new HttpClient(), apiVersion, isProd)
+            ) : this(new HttpClient(), apiVersion: apiVersion, isProd: isProd)
         {
         }
         


### PR DESCRIPTION
Fixes mismatch in constructor params that was causing the wrong JWT audience to be used.